### PR TITLE
[FIX] mail: Missing required header field: "Date"

### DIFF
--- a/class/send_mail.py
+++ b/class/send_mail.py
@@ -13,7 +13,7 @@ import os, sys, public, base64, json, re
 import smtplib, requests
 # import http_requests as requests
 from email.mime.text import MIMEText
-from email.utils import formataddr
+from email.utils import formataddr, formatdate
 
 class send_mail:
     __mail_config = '/www/server/panel/data/stmp_mail.json'
@@ -124,6 +124,7 @@ class send_mail:
         if not 'port' in self.__qq_mail_user: self.__qq_mail_user['port'] = 465
         try:
             msg = MIMEText(body, 'html', 'utf-8')
+            msg['Date'] = formatdate()
             msg['From'] = formataddr([self.__qq_mail_user['qq_mail'], self.__qq_mail_user['qq_mail']])
             if type(email)==str:
                 msg['To'] = formataddr([self.__qq_mail_user['qq_mail'], email.strip()])


### PR DESCRIPTION
Email notifications are being sent without an stablished Date. This causes smtp servers to reject the email.

# Before

```mail
The message WAS NOT relayed to:
  <xxxxxxx@gmail.com>:
   554 5.6.0 Bounce, id=01728-01 - BAD HEADER

This nondelivery report was generated by the program amavisd-new at host
mail.mydomain.net. Our internal reference code for your message is
01728-01/xxxxxxxgoIb5

INVALID HEADER

  Missing required header field: "Date"

Return-Path: <xxxxxxx@mydomain.net>
From: "xxxxxxx" <xxxxxxx@mydomain.net>
Subject: aaPanel Alert Test Email
```

![Selección_idpd3_183](https://user-images.githubusercontent.com/442938/222326925-5a2c1e45-efbd-4abf-9d61-39b977e88c54.png)


## After

```mail
Mime-Version: 1.0
Content-Transfer-Encoding: base64
From: "xxxxxxx" <xxxxxxx@mydomain.net>
To: "xxxxxxx" <xxxxxxx@gmail.com>
Subject: aaPanel Alert Test Email
```

![Selección_idpd3_184](https://user-images.githubusercontent.com/442938/222326964-4ec4f45d-b9a9-4e6f-a043-8de89b87e69b.png)

