### PR TITLE
fix: improve byte_conversion function to handle various units and spa…

### DIFF
--- a/class_v2/btdockerModelV2/dk_public.py
+++ b/class_v2/btdockerModelV2/dk_public.py
@@ -125,24 +125,37 @@ def get_mem_info():
 
 
 def byte_conversion(data):
-    data = data.lower()  # 将数据转换为小写字母形式
-    if "gib" in data:
-        return float(data.replace('gib', '')) * 1024 * 1024 * 1024
-    elif "mib" in data:
-        return float(data.replace('mib', '')) * 1024 * 1024
-    elif "kib" in data:
-        return float(data.replace('kib', '')) * 1024
-    elif "gb" in data:
-        return float(data.replace('gb', '')) * 1024 * 1024 * 1024
-    elif "mb" in data:
-        return float(data.replace('mb', '')) * 1024 * 1024
-    elif "kb" in data:
-        return float(data.replace('kb', '')) * 1024
-    elif "b" in data:
-        return float(data.replace('b', ''))
-    else:
-        return False
+    data = data.strip().lower().replace(" ", "")  # buang spasi dan ubah ke lowercase
 
+    try:
+        if "gib" in data:
+            return float(data.replace('gib', '')) * 1024 ** 3
+        elif "mib" in data:
+            return float(data.replace('mib', '')) * 1024 ** 2
+        elif "kib" in data:
+            return float(data.replace('kib', '')) * 1024
+        elif "gb" in data:
+            return float(data.replace('gb', '')) * 1024 ** 3
+        elif "mb" in data:
+            return float(data.replace('mb', '')) * 1024 ** 2
+        elif "kb" in data:
+            return float(data.replace('kb', '')) * 1024
+        elif "tb" in data:
+            return float(data.replace('tb', '')) * 1024 ** 4
+        elif "b" in data:
+            return float(data.replace('b', ''))
+        elif "g" in data:
+            return float(data.replace('g', '')) * 1024 ** 3
+        elif "m" in data:
+            return float(data.replace('m', '')) * 1024 ** 2
+        elif "k" in data:
+            return float(data.replace('k', '')) * 1024
+        elif "t" in data:
+            return float(data.replace('t', '')) * 1024 ** 4
+        else:
+            return False
+    except:
+        return 0
 
 def bytes_to_human_readable(bytes_num):
     """


### PR DESCRIPTION
…cing issues

- Added support for additional units such as 't', 'tb', 'g', 'm', 'k' to increase compatibility with Docker stats output.
- Added automatic whitespace stripping and lowercase conversion to ensure consistent parsing.
- Wrapped parsing logic in try-except to prevent runtime crashes on malformed input.
- Maintains backward compatibility with existing byte_conversion usages.

This resolves errors caused by values like ' 1.04t' or other unit variants.

[error link](https://www.aapanel.com/forum/d/23596-docker-overview-page-no-data-about-containers)

I have experienced it myself and done testing