### PR TITLE
Fix: Correctly parse my.cnf for MySQL log paths

### DIFF
--- a/class/database.py
+++ b/class/database.py
@@ -1536,7 +1536,6 @@ SetLink
         return result
 
     # 取慢日志
-# 取慢日志
     def GetSlowLogs(self, get):
         filename = ''
         try:

--- a/class/database.py
+++ b/class/database.py
@@ -1348,13 +1348,24 @@ SetLink
 
     # 获取错误日志
     def GetErrorLog(self, get):
-        path = self.GetMySQLInfo(get)['datadir']
         filename = ''
-        for n in os.listdir(path):
-            if len(n) < 5: continue
-            if n[-3:] == 'err':
-                filename = path + '/' + n
-                break
+        try:
+            mycnf = public.readFile('/etc/my.cnf')
+            if mycnf:
+                log_match = re.search(r'^\s*(?<!#)log[-_]error\s*=\s*(\S+)', mycnf, re.MULTILINE)
+                if log_match:
+                    path_from_cnf = log_match.group(1).strip().strip('\'"')
+                    if os.path.exists(path_from_cnf):
+                        filename = path_from_cnf
+        except:
+            pass
+        if not filename:
+            path = self.GetMySQLInfo(get)['datadir']
+            for n in os.listdir(path):
+                if len(n) < 5: continue
+                if n[-3:] == 'err':
+                    filename = path + '/' + n
+                    break
         if not os.path.exists(filename): return public.return_msg_gettext(False, public.lang("Configuration file not exist"))
         if hasattr(get, 'close'):
             public.writeFile(filename, '')
@@ -1525,10 +1536,24 @@ SetLink
         return result
 
     # 取慢日志
+# 取慢日志
     def GetSlowLogs(self, get):
-        path = self.GetMySQLInfo(get)['datadir'] + '/mysql-slow.log'
-        if not os.path.exists(path): return public.return_msg_gettext(False, public.lang("Log file does NOT exist!"))
-        return public.return_msg_gettext(True, public.GetNumLines(path, 100))
+        filename = ''
+        try:
+            mycnf = public.readFile('/etc/my.cnf')
+            if mycnf:
+                log_match = re.search(r'^\s*(?<!#)slow[-_]query[-_]log[-_]file\s*=\s*(\S+)', mycnf, re.MULTILINE)
+                if log_match:
+                    path_from_cnf = log_match.group(1).strip().strip('\'"')
+                    if os.path.exists(path_from_cnf):
+                        filename = path_from_cnf
+        except:
+            pass
+        if not filename:
+            path = self.GetMySQLInfo(get)['datadir'] + '/mysql-slow.log'
+            filename = path
+        if not os.path.exists(filename): return public.return_msg_gettext(False, public.lang("Log file does NOT exist!"))
+        return public.return_msg_gettext(True, public.GetNumLines(filename, 100))
 
     # 获取binlog文件列表
     def GetMySQLBinlogs(self, get):

--- a/class_v2/database_v2.py
+++ b/class_v2/database_v2.py
@@ -2622,15 +2622,27 @@ SetLink
 
     # 获取错误日志
     def GetErrorLog(self, get):
-        path = self.GetMySQLInfo(get)['message'].get('datadir')
-        if not os.path.exists(path):
-            return public.return_message(-1, 0, 'Database directory does not exist, please check if Mysql is installed properly')
         filename = ''
-        for n in os.listdir(path):
-            if len(n) < 5: continue
-            if n.endswith(".err"):
-                filename = os.path.join(path, n)
-                break
+        try:
+            mycnf = public.readFile('/etc/my.cnf')
+            if mycnf:
+                log_match = re.search(r'^\s*(?<!#)log[-_]error\s*=\s*(\S+)', mycnf, re.MULTILINE)
+                if log_match:
+                    path_from_cnf = log_match.group(1).strip().strip('\'"')
+                    if os.path.exists(path_from_cnf):
+                        filename = path_from_cnf
+        except Exception as e:
+            public.print_log("Unable to fetch Logs!: {}".format(str(e)))
+            filename = ''
+        if not filename:
+            path = self.GetMySQLInfo(get)['message'].get('datadir')
+            if not os.path.exists(path):
+                return public.return_message(-1, 0, 'Database directory does not exist, please check if Mysql is installed properly')
+            for n in os.listdir(path):
+                if len(n) < 5: continue
+                if n.endswith(".err"):
+                    filename = os.path.join(path, n)
+                    break
         if not os.path.exists(filename):
             return public.return_message(-1, 0, public.lang("Configuration file not exist"))
         if hasattr(get, 'close'):
@@ -2856,13 +2868,26 @@ SetLink
 
     # 取慢日志
     def GetSlowLogs(self, get):
-        path = self.GetMySQLInfo(get)['message'].get('datadir')
-        if not path:
-            return public.fail_v2("get MySQL datadir fail!")
-        path = path + '/mysql-slow.log'
-        if not os.path.exists(path):
+        filename = ''
+        try:
+            mycnf = public.readFile('/etc/my.cnf')
+            if mycnf:
+                log_match = re.search(r'^\s*(?<!#)slow[-_]query[-_]log[-_]file\s*=\s*(\S+)', mycnf, re.MULTILINE)
+                if log_match:
+                    path_from_cnf = log_match.group(1).strip().strip('\'"')
+                    if os.path.exists(path_from_cnf):
+                        filename = path_from_cnf
+        except Exception as e:
+            public.print_log("Unable to fetch Logs!: {}".format(str(e)))
+            filename = ''
+        if not filename:
+            path = self.GetMySQLInfo(get)['message'].get('datadir')
+            if not path:
+                return public.fail_v2("get MySQL datadir fail!")
+            filename = os.path.join(path, 'mysql-slow.log')
+        if not os.path.exists(filename):
             return public.fail_v2("Log file does NOT exist!")
-        return public.success_v2(public.GetNumLines(path, 100))
+        return public.success_v2(public.GetNumLines(filename, 100))
 
     # 获取binlog文件列表
     def GetMySQLBinlogs(self, get):


### PR DESCRIPTION
Hello,

This pull request fixes an issue where the Database Manager does not correctly detect the paths for the MySQL error log (log_error) and the slow query log (slow_query_log_file) if they are customized in /etc/my.cnf.

The Problem

The original code is hardcoded to look for these log files only within the default MySQL data directory. For example, it scans the data directory for any file ending in .err or assumes the slow log path is exactly [datadir]/mysql-slow.log.

This causes the log viewer in the panel to fail if a user has configured custom log paths for better server management.

The Solution

This PR introduces a more robust detection logic to the **GetErrorLog** and **GetSlowLogs** functions in both `panel/class/database.py` and `panel/class/database_v2.py`.

The new logic works as follows:

- Parses my.cnf First: The code now first attempts to read `/etc/my.cnf` to find the paths specified by the user.
- 
- Flexible Regex: The regular expression used handles both hyphenated (log-error) and underscored (log_error) directive names to support various MySQL/MariaDB conventions.
- 
- Ignores Comments: The logic safely ignores any directives that have been commented out with a #.
- 
- Safe Fallback: If no valid path is found in the configuration file, the code gracefully falls back to the original method of scanning the data directory. This ensures no functionality is lost for default setups.

With these changes, the Database Manager will now correctly display logs even when custom MySQL log paths are used.

**Additional Finding: Fail2ban Plugin**

During this investigation, I discovered that the official Fail2ban plugin suffers from the exact same issue. Its `set_mysql_anti` function also hardcodes the MySQL error log path instead of reading the configuration.

The code for that plugin does not appear to be in this public repository, so I could not include a fix. However, the same logic applied in this pull request can be used to correct the `fail2ban_main.py` file. I am noting it here for the development team's awareness.

Thank you for your consideration.