### PR TITLE
Fix: Let’s Encrypt SSL domain validation for multiple domains

### DIFF
--- a/class_v2/ssl_domainModelV2/api.py
+++ b/class_v2/ssl_domainModelV2/api.py
@@ -674,7 +674,7 @@ class DomainObject:
                 public.validate.trim_filter(),
             ])
             get.site_id = str(get.site_id)
-            domains = [x.strip() for x in list(set(get.domains.split(",")))]
+            domains = [x.strip() for x in list(set(get.domains.splitlines()))]
             domains.sort()
         except Exception as ex:
             public.print_log("error info: {}".format(ex))


### PR DESCRIPTION
When adding multiple domains for generating a Let’s Encrypt SSL certificate, the validation function failed because the get.domains string was split by lines instead of commas.
This mismatch caused an invalid MD5 hash to be generated, leading to errors such as "Order Not Found!".

Changes Introduced
Updated domain parsing logic in manual_apply_valid function:
Old behavior: Split domains by commas → get.domains.split(",")
New behavior: Split domains by new lines → get.domains.splitlines()