### PR TITLE
fix: handle string items in domain_list for ssl_push template filter

### DIFF
--- a/mod/base/push_mod/ssl_push.py
+++ b/mod/base/push_mod/ssl_push.py
@@ -133,7 +133,7 @@ class DomainEndTimeTask(BaseTask):
     def filter_template(self, template) -> dict:
         domain_list = DB("ssl_domains").select()
 
-        items = [{"title": i["domain"], "value": i["domain"]}for i in domain_list]
+        items = [{"title": (i if isinstance(i, str) else i["domain"]), "value": (i if isinstance(i, str) else i["domain"])} for i in domain_list]
 
         template["field"][0]["items"].extend(items)
         return template


### PR DESCRIPTION
Description

Fixes #267

What
When adding a task in Alarm List, the panel throws a fatal TypeError and the feature becomes completely unusable:

File "/www/server/panel/mod/base/push_mod/ssl_push.py", line 136, in filter_template
    items = [{"title": i["domain"], "value": i["domain"]} for i in domain_list]
                       ~^^^^^^^^^^
TypeError: string indices must be integers, not 'str'