### PR TITLE
Fix PostgreSQL password reset failing for existing users

### DIFF
--- a/class_v2/databaseModelV2/pgsqlModel.py
+++ b/class_v2/databaseModelV2/pgsqlModel.py
@@ -1046,8 +1046,7 @@ class main(databaseBase, panelPgsql):
                     newpassword
                 )
             )
-        if isError is not None:
-            return isError
+        
 
         # 修改SQLITE
         public.M('databases').where("id=? AND LOWER(type)=LOWER('PgSql')", (id,)).setField('password', newpassword)

--- a/class_v2/databaseModelV2/pgsqlModel.py
+++ b/class_v2/databaseModelV2/pgsqlModel.py
@@ -1028,12 +1028,24 @@ class main(databaseBase, panelPgsql):
             return public.fail_v2(public.lang("Failed to connect to the database!"))
 
         data = pgsql_obj.query('SELECT rolname FROM pg_roles;')
-        if username not in data:
-            # 添加用户
-            result = self.__CreateUsers(find['sid'], username, username, newpassword, "127.0.0.1")
+
+        roles = [x[0] for x in data] if isinstance(data, list) else []
+        
+        if username not in roles:
+            result = self.__CreateUsers(
+                find['sid'],
+                username,
+                username,
+                newpassword,
+                "127.0.0.1"
+            )
         else:
-            result = pgsql_obj.execute("""ALTER USER "{}" with password '{}';""".format(username, newpassword))
-        isError = self.IsSqlError(result)
+            result = pgsql_obj.execute(
+                """ALTER USER "{}" WITH PASSWORD '{}';""".format(
+                    username,
+                    newpassword
+                )
+            )
         if isError is not None:
             return isError
 

--- a/class_v2/databaseModelV2/pgsqlModel.py
+++ b/class_v2/databaseModelV2/pgsqlModel.py
@@ -1030,7 +1030,7 @@ class main(databaseBase, panelPgsql):
         data = pgsql_obj.query('SELECT rolname FROM pg_roles;')
         if username not in data:
             # 添加用户
-            result = self.__CreateUsers(find['sid'], username, username, newpassword, "127.0.0.0.1")
+            result = self.__CreateUsers(find['sid'], username, username, newpassword, "127.0.0.1")
         else:
             result = pgsql_obj.execute("""ALTER USER "{}" with password '{}';""".format(username, newpassword))
         isError = self.IsSqlError(result)


### PR DESCRIPTION
Fix PostgreSQL user existence check during password reset.

Previously, role existence was checked directly against query results returned from `SELECT rolname FROM pg_roles`, which returns tuples instead of plain strings.

This caused existing users to be incorrectly treated as non-existent, preventing `ALTER USER ... PASSWORD` from executing.

Changes:
- Normalize role query results into a flat list
- Perform existence checks against normalized role names
- Ensure existing users correctly enter password update flow


Before:
[('postgres',), ('user1',)]

Check:
if username not in data:

Always failed for existing users.

After:
['postgres', 'user1']

Membership check now works correctly.